### PR TITLE
Removed this ICall_free(pEvent) from application.

### DIFF
--- a/examples/rtos/CC2640R2_LAUNCHXL/bleapps/simple_peripheral_observer/src/app/simple_peripheral_observer.c
+++ b/examples/rtos/CC2640R2_LAUNCHXL/bleapps/simple_peripheral_observer/src/app/simple_peripheral_observer.c
@@ -1251,7 +1251,6 @@ static void SimpleBLEPeripheralObserver_processRoleEvent(gapPeriObsRoleEvent_t *
       }
         
       ICall_free(pEvent->deviceInfo.pEvtData);
-      ICall_free(pEvent);
       break;
 
     case GAP_DEVICE_DISCOVERY_EVENT:
@@ -1264,7 +1263,6 @@ static void SimpleBLEPeripheralObserver_processRoleEvent(gapPeriObsRoleEvent_t *
       Display_print0(dispHandle, 4, 0, "Scanning Off");
 
       ICall_free(pEvent->discCmpl.pDevList);
-      ICall_free(pEvent);
 
       break;
 


### PR DESCRIPTION
This ICall_free(pEvent) is the same one as in the GAPRole (profile) on line 962: https://github.com/ti-simplelink/ble_examples/blob/master/source/ti/blestack/profiles/roles/peripheral_observer.c#L962.

Please check https://e2e.ti.com/support/wireless_connectivity/bluetooth_low_energy/f/538/p/520223/1895316?tisearch=e2e-quicksearch&keymatch=GAPRole_StartDevice%20heap at TI e2e for the same issue as in an older SDK.

Removing this free will result in stable performance when continuously scheduling a new device discovery.